### PR TITLE
Detect description tag no matter if it is upper or lower letters.

### DIFF
--- a/lib/link_thumbnailer/doc.rb
+++ b/lib/link_thumbnailer/doc.rb
@@ -33,7 +33,7 @@ module LinkThumbnailer
     end
 
     def description
-      if element = xpath('//meta[@name="description" and @content]').first
+      if element = xpath("//meta[translate(@name,'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'description' and @content]").first
         return element.attributes['content'].value.strip
       end
 


### PR DESCRIPTION
New improved description tag discovery works for example for this page: http://www.gesund-heilfasten.de/basenpulver.html (with your  new version of lt unfortunatly this page gets back nil, the description detection however works fine)
