### PR TITLE
canonical url is used for non open graph pages

### DIFF
--- a/lib/link_thumbnailer.rb
+++ b/lib/link_thumbnailer.rb
@@ -82,6 +82,7 @@ module LinkThumbnailer
       self.object[:title]       = doc.title
       self.object[:description] = doc.description
       self.object[:images]      = self.img_parser.parse(doc.img_abs_urls.dup)
+      self.object[:url]         = doc.canonical_url || self.object[:url]
       return self.object if self.object.valid?
       nil
     end

--- a/lib/link_thumbnailer/doc.rb
+++ b/lib/link_thumbnailer/doc.rb
@@ -51,6 +51,13 @@ module LinkThumbnailer
       nil
     end
 
+    def canonical_url
+      if element = xpath("//link[translate(@rel, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ','abcdefghijklmnopqrstuvwxyz') = 'canonical' and @href]").first
+        return element.attributes['href'].value.strip
+      end
+      nil
+    end
+
     attr_accessor :source_url
 
   end


### PR DESCRIPTION
To avoid url parameters like order, sessionid etc, we could use the canonical url.
http://support.google.com/webmasters/bin/answer.py?hl=en&answer=139394
