### PR TITLE
Updated out-of-date nokogiri dependency

### DIFF
--- a/link_thumbnailer.gemspec
+++ b/link_thumbnailer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'hashie',                '>= 1.2.0'
   gem.add_dependency 'net-http-persistent',   '~> 2.7'
   gem.add_dependency 'rmagick',               '~> 2.13.1'
-  gem.add_dependency 'json',                  '~> 1.7.6'
+  gem.add_dependency 'json',                  '>= 1.7.6', '< 1.9'
 
   gem.add_development_dependency 'bundler',  '~> 1.3'
   gem.add_development_dependency 'rspec',    '~> 2.14'


### PR DESCRIPTION
Should minimize bundle dependency conflicts, since lots of stuff relies on nokogiri. Cursory check didn't reveal any issues with using the newer version of nokogiri.
