### PR TITLE
Update img_parser.rb

### DIFF
--- a/lib/link_thumbnailer/img_parser.rb
+++ b/lib/link_thumbnailer/img_parser.rb
@@ -31,7 +31,7 @@ module LinkThumbnailer
     end
 
     def parse_one(img_url)
-      FastImage.new(img_url, raise_on_failure: false)
+      FastImage.new(img_url.to_s, raise_on_failure: false)
     rescue StandardError
       nil
     end


### PR DESCRIPTION
`FastImage.new(img_url)` raises `TypeError: no implicit conversion of Fixnum into String` and `images` always empty.
