### PR TITLE
Handle empty og:image value

### DIFF
--- a/lib/link_thumbnailer/opengraph.rb
+++ b/lib/link_thumbnailer/opengraph.rb
@@ -9,7 +9,7 @@ module LinkThumbnailer
         end
 
         object[:images] = []
-        if object[:image]
+        if object[:image] && !object[:image].empty?
           object[:images] << { source_url: object[:image] }
         end
 

--- a/spec/examples/empty_og_image_example.html
+++ b/spec/examples/empty_og_image_example.html
@@ -1,0 +1,9 @@
+<html  xmlns:og="http://opengraphprotocol.org/schema/">
+  <head>
+    <meta charset="utf-8"/>
+    <meta property="og:title" content="Foo Title">
+    <meta property="og:image" content="">
+    <title>Foo</title>
+  </head>
+
+</html>

--- a/spec/link_thumbnailer_spec.rb
+++ b/spec/link_thumbnailer_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 
 describe LinkThumbnailer do
 
-  let(:og_example)    { File.open(File.dirname(__FILE__) + '/examples/og_example.html').read() }
-  let(:example)       { File.open(File.dirname(__FILE__) + '/examples/example.html').read() }
-  let(:empty_example) { File.open(File.dirname(__FILE__) + '/examples/empty_example.html').read() }
+  let(:og_example)             { File.open(File.dirname(__FILE__) + '/examples/og_example.html').read() }
+  let(:example)                { File.open(File.dirname(__FILE__) + '/examples/example.html').read() }
+  let(:empty_example)          { File.open(File.dirname(__FILE__) + '/examples/empty_example.html').read() }
+  let(:empty_og_image_example) { File.open(File.dirname(__FILE__) + '/examples/empty_og_image_example.html').read() }
 
   it { should respond_to :configuration }
   it { should respond_to :configure }
@@ -156,6 +157,16 @@ describe LinkThumbnailer do
 
           it { expect(LinkThumbnailer.generate('http://foo.com/')).to be_nil }
           it { expect { LinkThumbnailer.generate('http://foo.com/') }.to_not raise_exception }
+
+        end
+
+        context "and empty og value" do
+
+          before do
+            stub_request(:get, 'http://foo.com/').to_return(status: 200, body: empty_og_image_example, headers: {})
+          end
+
+          it { expect(LinkThumbnailer.generate('http://foo.com/')).to be_nil }
 
         end
 


### PR DESCRIPTION
I found that some sites have empty og:image value, like below. It'd be nice to handle this edge case.

``` html
<meta property="og:image" content="" name="">
```

But in `opengraph.rb` we're not checking empty string so `object.valid?`still returns true.

With this change `object[:images]` will remain blank in this case, and `object.valid?` will return false in strict mode.
