### PR TITLE
Use website url for Vimeo videos

### DIFF
--- a/lib/link_thumbnailer/scrapers/opengraph/video.rb
+++ b/lib/link_thumbnailer/scrapers/opengraph/video.rb
@@ -13,6 +13,10 @@ module LinkThumbnailer
         
         def attribute
           if website.url.host =~ /vimeo/
+            # Vimeo uses a SWF file for its og:video property which doesn't
+            # provide any metadata for the VideoInfo gem downstream. Using
+            # og:url means VideoInfo is passed a webpage URL with metadata
+            # it can parse:
             'og:url'
           else
             super


### PR DESCRIPTION
Vimeo video pages have a swf for the `og:video` meta tag, which cannot be parsed by VideoInfo into something meaningful. So a Vimeo video is missing is `id`, `duration` and embed code.

Switching to `og:url` specifically for Vimeo pages fixes this (the video metadata returned is now far more detailed).

This doesn't feel like an ideal solution to the problem, but it works. If you have a better solution then I'm happy to see that implemented instead.
