### PR TITLE
Support for http proxy

### DIFF
--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -43,6 +43,7 @@ module LinkThumbnailer
     def set_http_options
       http.verify_mode  = ::OpenSSL::SSL::VERIFY_NONE unless ssl_required?
       http.open_timeout = http_timeout
+      http.proxy = :ENV
     end
 
     def perform_request


### PR DESCRIPTION
It allows the underlying `::Net::HTTP::Persistent` transport to connect via proxy whether  `ENV['HTTP_PROXY']` vars  is available

More info:

https://github.com/drbrain/net-http-persistent/blob/master/lib/net/http/persistent.rb#L932-L950
