### PR TITLE
Allow to configure the read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ LinkThumbnailer.configure do |config|
   #
   # See http://www.ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout
   #
-  # config.http_timeout = 5
+  # config.http_open_timeout = 5
 
   # List of blacklisted urls you want to skip when searching for images.
   #

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -18,7 +18,7 @@ LinkThumbnailer.configure do |config|
   #
   # See http://www.ruby-doc.org/stdlib-2.1.1/libdoc/net/http/rdoc/Net/HTTP.html#open_timeout
   #
-  # config.http_timeout = 5
+  # config.http_open_timeout = 5
 
   # List of blacklisted urls you want to skip when searching for images.
   #

--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -23,8 +23,8 @@ module LinkThumbnailer
 	class Configuration
 
     attr_accessor :redirect_limit, :blacklist_urls, :user_agent,
-                  :verify_ssl, :http_timeout, :attributes, :graders,
-                  :description_min_length, :positive_regex, :negative_regex,
+                  :verify_ssl, :http_open_timeout, :http_read_timeout, :attributes,
+                  :graders, :description_min_length, :positive_regex, :negative_regex,
                   :image_limit, :image_stats
 
     # Create a new instance.
@@ -34,7 +34,8 @@ module LinkThumbnailer
       @redirect_limit         = 3
       @user_agent             = 'link_thumbnailer'
       @verify_ssl             = true
-      @http_timeout           = 5
+      @http_open_timeout      = 5
+      @http_read_timeout      = 5
       @blacklist_urls         = [
         %r{^http://ad\.doubleclick\.net/},
         %r{^http://b\.scorecardresearch\.com/},

--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -27,6 +27,9 @@ module LinkThumbnailer
                   :graders, :description_min_length, :positive_regex, :negative_regex,
                   :image_limit, :image_stats
 
+    alias_method :http_timeout, :http_open_timeout
+    alias_method :http_timeout=, :http_open_timeout=
+
     # Create a new instance.
     #
     # @return [LinkThumbnailer::Configuration]

--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -42,7 +42,8 @@ module LinkThumbnailer
 
     def set_http_options
       http.verify_mode  = ::OpenSSL::SSL::VERIFY_NONE unless ssl_required?
-      http.open_timeout = http_timeout
+      http.open_timeout = http_open_timeout
+      http.read_timeout = http_read_timeout
       http.proxy = :ENV
     end
 
@@ -73,8 +74,12 @@ module LinkThumbnailer
       config.user_agent
     end
 
-    def http_timeout
-      config.http_timeout
+    def http_open_timeout
+      config.http_open_timeout
+    end
+
+    def http_read_timeout
+      config.http_read_timeout
     end
 
     def ssl_required?

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -18,6 +18,11 @@ describe LinkThumbnailer::Configuration do
   it { expect(instance.image_limit).to            eq(5) }
   it { expect(instance.image_stats).to            eq(true) }
 
+  describe "#http_timeout" do
+    it { expect(instance.method(:http_timeout)).to eq(instance.method(:http_open_timeout)) }
+    it { expect(instance.method(:http_timeout=)).to eq(instance.method(:http_open_timeout=)) }
+  end
+
   describe '.config' do
 
     it { expect(LinkThumbnailer.config).to be_a(described_class) }

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -7,7 +7,8 @@ describe LinkThumbnailer::Configuration do
   it { expect(instance.redirect_limit).to         eq(3) }
   it { expect(instance.user_agent).to             eq('link_thumbnailer') }
   it { expect(instance.verify_ssl).to             eq(true) }
-  it { expect(instance.http_timeout).to           eq(5) }
+  it { expect(instance.http_open_timeout).to      eq(5) }
+  it { expect(instance.http_read_timeout).to      eq(5) }
   it { expect(instance.blacklist_urls).to_not     be_empty }
   it { expect(instance.attributes).to             eq([:title, :images, :description, :videos, :favicon]) }
   it { expect(instance.graders).to_not            be_empty }

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 
 describe LinkThumbnailer::Processor do
 
@@ -151,17 +152,29 @@ describe LinkThumbnailer::Processor do
 
     describe 'open_timeout' do
 
-      let(:http_timeout) { 1 }
+      let(:http_open_timeout) { 1 }
 
       before do
-        instance.stub(:http_timeout).and_return(http_timeout)
+        instance.stub(:http_open_timeout).and_return(http_open_timeout)
         action
       end
 
-      it { expect(http.open_timeout).to eq(http_timeout) }
+      it { expect(http.open_timeout).to eq(http_open_timeout) }
 
     end
 
+    describe 'read_timeout' do
+
+      let(:http_read_timeout) { 1 }
+
+      before do
+        instance.stub(:http_read_timeout).and_return(http_read_timeout)
+        action
+      end
+
+      it { expect(http.read_timeout).to eq(http_read_timeout) }
+
+    end
   end
 
   describe '#perform_request' do
@@ -250,16 +263,29 @@ describe LinkThumbnailer::Processor do
 
   end
 
-  describe '#http_timeout' do
+  describe '#http_open_timeout' do
 
-    let(:http_timeout)  { 1 }
-    let(:action)        { instance.send(:http_timeout) }
+    let(:http_open_timeout)  { 1 }
+    let(:action)        { instance.send(:http_open_timeout) }
 
     before do
-      instance.config.http_timeout = http_timeout
+      instance.config.http_open_timeout = http_open_timeout
     end
 
-    it { expect(action).to eq(http_timeout) }
+    it { expect(action).to eq(http_open_timeout) }
+
+  end
+
+  describe '#http_read_timeout' do
+
+    let(:http_read_timeout)  { 1 }
+    let(:action)        { instance.send(:http_read_timeout) }
+
+    before do
+      instance.config.http_read_timeout = http_read_timeout
+    end
+
+    it { expect(action).to eq(http_read_timeout) }
 
   end
 

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe LinkThumbnailer::Processor do
 


### PR DESCRIPTION
Hi!
I've added the option to configure the `Net::HTTP::Persistent#read_timeout`, and altered the name of the existing configuration for the `Net::HTTP::Persistent#open_timeout` so it's clearer now.