### PR TITLE
Strip invalid UTF-8 data from response

### DIFF
--- a/lib/link_thumbnailer/model.rb
+++ b/lib/link_thumbnailer/model.rb
@@ -9,7 +9,7 @@ module LinkThumbnailer
 
     def sanitize(str)
       return unless str
-      str.strip.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').gsub(/[\r\n\f]+/, "\n")
+      str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').strip.gsub(/[\r\n\f]+/, "\n")
     end
 
   end

--- a/lib/link_thumbnailer/model.rb
+++ b/lib/link_thumbnailer/model.rb
@@ -9,7 +9,7 @@ module LinkThumbnailer
 
     def sanitize(str)
       return unless str
-      str.strip.gsub(/[\r\n\f]+/, "\n")
+      str.strip.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').gsub(/[\r\n\f]+/, "\n")
     end
 
   end


### PR DESCRIPTION
Fixes #50. Extra commit switches the order of string function calls as originally suggested by @gottfrois  because `#strip` can actually die on invalid bytes too.