### PR TITLE
Change another solution to handle utf-8 string

### DIFF
--- a/lib/link_thumbnailer/model.rb
+++ b/lib/link_thumbnailer/model.rb
@@ -9,8 +9,9 @@ module LinkThumbnailer
 
     def sanitize(str)
       return unless str
-      str.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').strip.gsub(/[\r\n\f]+/, "\n")
-    end
 
+      str.encode!("UTF-16", "UTF-8", invalid: :replace, undef: :replace, replace: "")
+      str.encode!("UTF-8", "UTF-16").strip.gsub(/[\r\n\f]+/, "\n")
+    end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,3 +1,4 @@
+# -*- encoding : utf-8 -*-
 require 'spec_helper'
 
 describe LinkThumbnailer::Model do

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -12,6 +12,13 @@ describe LinkThumbnailer::Model do
 
     it { expect(action).to eq(result) }
 
+    context "when string includes utf-8 characters" do
+      let(:str) { "中文" }
+
+      it "should keeps those characters" do
+        expect(instance.send(:sanitize, str)).to eq(str)
+      end
+    end
   end
 
 end


### PR DESCRIPTION
The original solution will cause character lost like

```
# Chinese character will be replaced
"中文".encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').strip.gsub(/[\r\n\f]+/, "\n")
=>  ""

# New solution
str = "中文"
str.encode!("UTF-16", "UTF-8", invalid: :replace, undef: :replace, replace: "")
=> "\uFEFF\u4E2D\u6587"
str.encode!("UTF-8", "UTF-16").strip.gsub(/[\r\n\f]+/, "\n")
=> "中文"
```