### PR TITLE
fix: Ensure Video scraping on the same protocol as original request

### DIFF
--- a/lib/link_thumbnailer/models/website.rb
+++ b/lib/link_thumbnailer/models/website.rb
@@ -36,6 +36,11 @@ module LinkThumbnailer
         @images.sort!
       end
 
+      def scheme
+        uri = URI.parse("#{url}")
+        uri.scheme
+      end
+
       def as_json(*)
         {
           url:          url.to_s,

--- a/lib/link_thumbnailer/scrapers/base.rb
+++ b/lib/link_thumbnailer/scrapers/base.rb
@@ -62,6 +62,11 @@ module LinkThumbnailer
         model_class.new(node, text)
       end
 
+      def scheme
+        # Extract the schema from the url
+        uri = URI.parse("#{@website.url}")
+        uri.scheme
+      end
     end
   end
 end

--- a/lib/link_thumbnailer/scrapers/base.rb
+++ b/lib/link_thumbnailer/scrapers/base.rb
@@ -63,9 +63,7 @@ module LinkThumbnailer
       end
 
       def scheme
-        # Extract the schema from the url
-        uri = URI.parse("#{@website.url}")
-        uri.scheme
+        website.scheme
       end
     end
   end

--- a/lib/link_thumbnailer/scrapers/opengraph/video.rb
+++ b/lib/link_thumbnailer/scrapers/opengraph/video.rb
@@ -22,7 +22,7 @@ module LinkThumbnailer
           private
 
           def model
-            nodes.map { |n| modelize(n, n.attributes['content'].to_s) }
+            nodes.map { |n| modelize(n, n.attributes['content'].to_s) if n.attributes['content'].to_s.start_with? scheme }
           end
 
           def modelize(node, text = nil)

--- a/spec/models/website_spec.rb
+++ b/spec/models/website_spec.rb
@@ -46,4 +46,28 @@ describe LinkThumbnailer::Models::Website do
 
   end
 
+  describe '#scheme' do
+
+    subject { ::LinkThumbnailer::Models::Website.new }
+
+    before do
+      subject.url = url
+    end
+
+    context 'when protocol is https' do
+      let(:url) { "https://foo.com" }
+
+      it 'returns https scheme' do
+        expect(subject.scheme).to eq "https"
+      end
+    end
+
+    context 'when protocol is http' do
+      let(:url) { "http://bar.com" }
+
+      it 'returns http scheme' do
+        expect(subject.scheme).to eq "http"
+      end
+    end
+  end
 end


### PR DESCRIPTION
OK, after looking at #69, I found that `nodes` variable here https://github.com/gottfrois/link_thumbnailer/blob/master/lib/link_thumbnailer/scrapers/opengraph/video.rb#L25 will have both `https://youtube....` and an `http://youtube...` sources. As the second one (http) does not allow to fetch any content, the Oga parser will fail with ArgumentError. So the solution is to only include into `nodes` the URLs with the same scheme. I haven't written any test for that though =|.

I'd like somebody to run this code and see if it still works OK with Video pages supporting OpenGraph and which are on http protocol