### PR TITLE
update video_info version to 2.5 which supports Youtube API v3

### DIFF
--- a/link_thumbnailer.gemspec
+++ b/link_thumbnailer.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rake',                   '>= 0.9'
   spec.add_dependency 'nokogiri',               '~> 1.6'
   spec.add_dependency 'net-http-persistent',    '~> 2.9'
-  spec.add_dependency 'video_info',             '~> 2.4'
+  spec.add_dependency 'video_info',             '~> 2.6'
   spec.add_dependency 'image_info',             '~> 1.0'
 end


### PR DESCRIPTION
Bump video_info to 2.6 to solve the issue #69.
It also introduces new functionalities described [here](https://github.com/thibaudgg/video_info/issues/103)