### PR TITLE
Override User-Agent header properly

### DIFF
--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -39,7 +39,7 @@ module LinkThumbnailer
 
     def set_http_headers(headers = {})
       headers.each { |k, v| http.headers[k] = v }
-      http.headers['User-Agent']               = user_agent
+      http.override_headers['User-Agent']      = user_agent
       http.override_headers['Accept-Encoding'] = 'none'
     end
 

--- a/spec/processor_spec.rb
+++ b/spec/processor_spec.rb
@@ -106,7 +106,7 @@ describe LinkThumbnailer::Processor do
   describe '#set_http_headers' do
 
     let(:user_agent)  { 'foo' }
-    let(:headers)     { instance.send(:http).headers }
+    let(:headers)     { instance.send(:http).override_headers }
     let(:action)      { instance.send(:set_http_headers) }
 
     before do


### PR DESCRIPTION
It should use `override_headers` instead of `headers` because it appends the User-Agent to the existing one. See https://github.com/drbrain/net-http-persistent/blob/master/lib/net/http/persistent.rb#L101-L104