### PR TITLE
Fixes Issue #88 - undefined method `size' for nil:NilClass

### DIFF
--- a/lib/link_thumbnailer/scrapers/opengraph/image.rb
+++ b/lib/link_thumbnailer/scrapers/opengraph/image.rb
@@ -1,4 +1,5 @@
 require 'link_thumbnailer/scrapers/opengraph/base'
+require 'link_thumbnailer/uri'
 
 module LinkThumbnailer
   module Scrapers
@@ -20,7 +21,10 @@ module LinkThumbnailer
           end
 
           def model
-            nodes.map { |n| modelize(n, n.attributes['content'].to_s) }
+            nodes.map do |n|
+              uri =  LinkThumbnailer::URI.new(n.attributes['content'])
+              modelize(n, uri.to_s) if uri.valid?
+            end.compact
           end
 
           def modelize(node, text = nil)

--- a/lib/link_thumbnailer/uri.rb
+++ b/lib/link_thumbnailer/uri.rb
@@ -1,0 +1,18 @@
+module LinkThumbnailer
+  class URI
+
+    attr_reader :attribute
+
+    def initialize(uri)
+      @attribute = uri.to_s
+    end
+
+    def valid?
+      !!(attribute =~ ::URI::regexp)
+    end
+
+    def to_s
+      attribute
+    end
+  end
+end

--- a/spec/uri_spec.rb
+++ b/spec/uri_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe LinkThumbnailer::URI do
+
+  let(:uri)       { 'http://foo.com' }
+  let(:instance)  { described_class.new(uri) }
+
+  describe '#valid?' do
+
+    let(:action) { instance.send(:valid?) }
+
+    context 'when bad format' do
+
+      before do
+        instance.stub(:attribute).and_return("/invalid/path")
+      end
+
+      it { expect(action).to be_falsey }
+
+    end
+
+    context 'when valid format' do
+
+      before do
+        instance.stub(:attribute).and_return("http://foo.com")
+      end
+
+      it { expect(action).to be_truthy }
+
+    end
+
+  end
+
+  describe '#to_s' do
+
+    let(:action) { instance.to_s }
+
+    it { expect(action).to eq(uri) }
+
+  end
+
+end


### PR DESCRIPTION
This is a proposed fix for #88 
Cause of the bug was that the value of `og:image` for that page had some invalid url's in it.

```
/screenshot/ef3846ca11dd440b9c845476d1e6d0fba84609dd.png
/dv/HGEuXkjm_cFp0sA_z3NRKsbqqaA/yui3/opengraph/assets/science.png
/dv/HGEuXkjm_cFp0sA_z3NRKsbqqaA/yui3/opengraph/assets/general.png
```
which caused [image_info](https://github.com/gottfrois/image_info) to return `nil` and hence the errors on calling methods like `size`, `type`, etc.