### PR TITLE
Match xpath nodes if attribute content is present

### DIFF
--- a/lib/link_thumbnailer/scrapers/base.rb
+++ b/lib/link_thumbnailer/scrapers/base.rb
@@ -47,7 +47,7 @@ module LinkThumbnailer
         value     = options.fetch(:value, :content)
         attribute = options.fetch(:attribute, attribute_name)
 
-        document.xpath("//meta[translate(@#{key},'#{abc.upcase}','#{abc}') = '#{attribute}' and @#{value}]")
+        document.xpath("//meta[translate(@#{key},'#{abc.upcase}','#{abc}') = '#{attribute}' and string-length(@#{value}) > 0]")
       end
 
       def abc


### PR DESCRIPTION
Make sure it only matches nodes that have attributes that is not blank. So only the last node will match on the following example:
```
<meta content="" property="og:image">
<meta content="http://example.com/image.jpg" property="og:image">
```
