### PR TITLE
Prevent code to break when image is defective

### DIFF
--- a/lib/link_thumbnailer/image_parser.rb
+++ b/lib/link_thumbnailer/image_parser.rb
@@ -6,7 +6,7 @@ module LinkThumbnailer
     attr_reader :images
 
     def initialize(urls)
-      @images = perform? ? ::ImageInfo.from(urls, max_concurrency: max_concurrency) : Array(urls).compact.map(&method(:build_default_image))
+      @images = perform? ? image_info(urls) : default_images(urls)
     end
 
     def size
@@ -19,6 +19,10 @@ module LinkThumbnailer
 
     private
 
+    def default_images(urls)
+      Array(urls).compact.map(&method(:build_default_image))
+    end
+
     def build_default_image(uri)
       NullImage.new(uri)
     end
@@ -29,6 +33,12 @@ module LinkThumbnailer
 
     def max_concurrency
       ::LinkThumbnailer.page.config.max_concurrency
+    end
+
+    def image_info(urls)
+      ::ImageInfo.from(urls, max_concurrency: max_concurrency)
+    rescue
+      default_images(urls)
     end
 
     class NullImage


### PR DESCRIPTION
I tried to fetch data from [this url](https://codeascraft.com/2016/10/19/being-an-effective-ally-to-women-and-non-binary-people/) and came across a weird problem: their og:image is defective. In order to prevent this gem to break for trying to evaluate the size of problematic images, I created this PR to provide a quick fix.

The error will occur when trying to execute this code: `::ImageInfo.from(urls, max_concurrency: max_concurrency)`. It is possible to reproduce the problem in the console:

```ruby
  LinkThumbnailer.generate('https://codeascraft.com/2016/10/19/being-an-effective-ally-to-women-and-non-binary-people/')
```

You will get this:

```
ETHON: started MULTI
NoMethodError: undefined method `-' for nil:NilClass
```

The error actually happens from the outside, in the [image_size](https://github.com/toy/image_size) gem. This gem is called by the [image_info](https://github.com/gottfrois/image_info). I already requested a [pull request](https://github.com/gottfrois/image_info/pull/5) there, but I am not really sure if the fix should be better implemented here or there, so I decided to propose the change here as well.
