### PR TITLE
Fix image URL's when base tag is an invalid URL

### DIFF
--- a/lib/link_thumbnailer/scrapers/default/images.rb
+++ b/lib/link_thumbnailer/scrapers/default/images.rb
@@ -57,7 +57,10 @@ module LinkThumbnailer
 
         def base_href
           base = document.at('//head/base')
-          base['href'] if base
+          href = base['href']
+          href if base && ::URI.parse(href).host
+        rescue ::URI::InvalidURIError
+          nil
         end
 
         def model_class


### PR DESCRIPTION
Fixes #108. The issue occurs when the page has a tag `<base href="/">`.