### PR TITLE
add configuration option to limit download size

### DIFF
--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -83,9 +83,9 @@ LinkThumbnailer.configure do |config|
   #
   # config.scrapers = [:opengraph, :default]
 
-  # Limit for download size in bytes.
+  # Limit for download size in bytes. When using ActiveSupport, you can also use values like 10.megabytes
   #
-  # config.download_size_limit = 10.megabytes
+  # config.download_size_limit = 10 * 1024 * 1024
 
   # Sets the default encoding.
   #

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -83,6 +83,10 @@ LinkThumbnailer.configure do |config|
   #
   # config.scrapers = [:opengraph, :default]
 
+  # Limit for download size in bytes. For example, 10.megabytes
+  #
+  # config.download_size_limit = nil
+
   # Sets the default encoding.
   #
   # config.encoding = 'utf-8'

--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -83,9 +83,9 @@ LinkThumbnailer.configure do |config|
   #
   # config.scrapers = [:opengraph, :default]
 
-  # Limit for download size in bytes. For example, 10.megabytes
+  # Limit for download size in bytes.
   #
-  # config.download_size_limit = nil
+  # config.download_size_limit = 10.megabytes
 
   # Sets the default encoding.
   #

--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -65,7 +65,7 @@ module LinkThumbnailer
       @max_concurrency = 20
       @scrapers = [:opengraph, :default]
       @http_override_headers = { 'Accept-Encoding' => 'none' }
-      @download_size_limit = 10.megabytes
+      @download_size_limit = 10 * 1024 * 1024
       @encoding = 'utf-8'
     end
 

--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -65,7 +65,7 @@ module LinkThumbnailer
       @max_concurrency = 20
       @scrapers = [:opengraph, :default]
       @http_override_headers = { 'Accept-Encoding' => 'none' }
-      @download_size_limit = nil
+      @download_size_limit = 10.megabytes
       @encoding = 'utf-8'
     end
 

--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -28,7 +28,7 @@ module LinkThumbnailer
                   :verify_ssl, :http_open_timeout, :http_read_timeout, :attributes,
                   :graders, :description_min_length, :positive_regex, :negative_regex,
                   :image_limit, :image_stats, :raise_on_invalid_format, :max_concurrency,
-                  :scrapers, :http_override_headers, :encoding
+                  :scrapers, :http_override_headers, :download_size_limit, :encoding
 
     alias_method :http_timeout, :http_open_timeout
     alias_method :http_timeout=, :http_open_timeout=
@@ -65,6 +65,7 @@ module LinkThumbnailer
       @max_concurrency = 20
       @scrapers = [:opengraph, :default]
       @http_override_headers = { 'Accept-Encoding' => 'none' }
+      @download_size_limit = nil
       @encoding = 'utf-8'
     end
 

--- a/lib/link_thumbnailer/exceptions.rb
+++ b/lib/link_thumbnailer/exceptions.rb
@@ -8,4 +8,5 @@ module LinkThumbnailer
   ScraperInvalid     = Class.new(Exceptions)
   HTTPError          = Class.new(Exceptions)
   SyntaxError        = Class.new(Exceptions)
+  DownloadSizeLimit  = Class.new(Exceptions)
 end

--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -74,7 +74,7 @@ module LinkThumbnailer
     end
 
     def request_in_chunks
-      body     = +''
+      body     = String.new
       response = http.request(url) do |resp|
         raise ::LinkThumbnailer::DownloadSizeLimit if too_big_download_size?(resp.content_length)
         resp.read_body do |chunk|

--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -138,7 +138,7 @@ module LinkThumbnailer
     end
 
     def too_big_download_size?(size)
-      size.to_i > download_size_limit
+      size.to_i > download_size_limit.to_i
     end
 
     def url=(url)

--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -138,7 +138,7 @@ module LinkThumbnailer
     end
 
     def too_big_download_size?(size)
-      download_size_limit && (size.to_i > download_size_limit)
+      size.to_i > download_size_limit
     end
 
     def url=(url)

--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -53,7 +53,7 @@ module LinkThumbnailer
     end
 
     def perform_request
-      response          = http.request(url)
+      response          = request_in_chunks
       headers           = {}
       headers['Cookie'] = response['Set-Cookie'] if response['Set-Cookie'].present?
 
@@ -71,6 +71,19 @@ module LinkThumbnailer
       else
         response.error!
       end
+    end
+
+    def request_in_chunks
+      body     = +''
+      response = http.request(url) do |resp|
+        raise ::LinkThumbnailer::DownloadSizeLimit if too_big_download_size?(resp.content_length)
+        resp.read_body do |chunk|
+          body.concat(chunk)
+          raise ::LinkThumbnailer::DownloadSizeLimit if too_big_download_size?(body.length)
+        end
+      end
+      response.body = body
+      response
     end
 
     def resolve_relative_url(location)
@@ -101,6 +114,10 @@ module LinkThumbnailer
       config.verify_ssl
     end
 
+    def download_size_limit
+      config.download_size_limit
+    end
+
     def too_many_redirections?
       redirect_count > redirect_limit
     end
@@ -118,6 +135,10 @@ module LinkThumbnailer
       return true if response['Content-Type'] =~ /text\/xml/
       return true if response['Content-Type'] =~ /text\/plain/
       false
+    end
+
+    def too_big_download_size?(size)
+      download_size_limit && (size.to_i > download_size_limit)
     end
 
     def url=(url)


### PR DESCRIPTION
This PR solves #80 and partially replaces the pull request #103 by @novill by adding an option to limit the downloaded file size (e.g. `config.download_size_limit = 3.megabytes`), if surpassed it will raise `LinkThumbnailer::DownloadSizeLimit`. 

Not included in this PR is the part of the PR #103 which allows image and video direct link parsing, as it's not related (@gottfrois please check if it's of future use before removing the referenced PR by novill).