### PR TITLE
Add option to fetch full content of the webpage

### DIFF
--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -48,7 +48,7 @@ module LinkThumbnailer
         %r{^http://pixel\.quantserve\.com/},
         %r{^http://s7\.addthis\.com/}
       ]
-      @attributes             = [:title, :images, :description, :videos, :favicon]
+      @attributes             = [:title, :images, :description, :videos, :favicon, :body]
       @graders                = [
         ->(description) { ::LinkThumbnailer::Graders::Length.new(description) },
         ->(description) { ::LinkThumbnailer::Graders::HtmlAttribute.new(description, :class) },

--- a/lib/link_thumbnailer/model.rb
+++ b/lib/link_thumbnailer/model.rb
@@ -16,5 +16,13 @@ module LinkThumbnailer
       str = str.encode("UTF-8", "UTF-16").strip.gsub(/[\r\n\f]+/, "\n")
       str
     end
+
+    def squish(str)
+      return unless str
+      str = str.gsub(/\A[[:space:]]+/, '')
+      str = str.gsub(/[[:space:]]+\z/, '')
+      str = str.gsub(/[[:space:]]+/, ' ')
+      str
+    end
   end
 end

--- a/lib/link_thumbnailer/model.rb
+++ b/lib/link_thumbnailer/model.rb
@@ -19,9 +19,9 @@ module LinkThumbnailer
 
     def squish(str)
       return unless str
-      str = str.gsub(/\A[[:space:]]+/, '')
-      str = str.gsub(/[[:space:]]+\z/, '')
-      str = str.gsub(/[[:space:]]+/, ' ')
+      str.gsub!(/\A[[:space:]]+/, '')
+      str.gsub!(/[[:space:]]+\z/, '')
+      str.gsub!(/[[:space:]]+/, ' ')
       str
     end
   end

--- a/lib/link_thumbnailer/models/body.rb
+++ b/lib/link_thumbnailer/models/body.rb
@@ -6,15 +6,15 @@ module LinkThumbnailer
   module Models
     class Body < ::LinkThumbnailer::Model
 
-      attr_reader :node, :text
+      attr_reader :node, :paragraphs
 
       def initialize(node, text = nil)
         @node = node
-        @text = sanitize(squish(node.map(&:text).join(' ')))
+        @paragraphs = node.map{|n| sanitize(squish(n.text.to_s))}
       end
 
       def to_s
-        text
+        @paragraphs.join(' ')
       end
 
     end

--- a/lib/link_thumbnailer/models/body.rb
+++ b/lib/link_thumbnailer/models/body.rb
@@ -10,7 +10,7 @@ module LinkThumbnailer
 
       def initialize(node, text = nil)
         @node = node
-        @text = sanitize(node.map(&:text).join(' '))
+        @text = sanitize(node.map(&:text).join(' ').squish)
       end
 
       def to_s

--- a/lib/link_thumbnailer/models/body.rb
+++ b/lib/link_thumbnailer/models/body.rb
@@ -10,7 +10,7 @@ module LinkThumbnailer
 
       def initialize(node, text = nil)
         @node = node
-        @paragraphs = node.map{|n| sanitize(squish(n.text.to_s))}
+        @paragraphs = node.map{|n| sanitize(squish(n.text.to_s))}.reject{|n| n.empty?}
       end
 
       def to_s

--- a/lib/link_thumbnailer/models/body.rb
+++ b/lib/link_thumbnailer/models/body.rb
@@ -10,7 +10,7 @@ module LinkThumbnailer
 
       def initialize(node, text = nil)
         @node = node
-        @text = sanitize(node.map(&:text).join(' ').squish)
+        @text = sanitize(squish(node.map(&:text).join(' ')))
       end
 
       def to_s

--- a/lib/link_thumbnailer/models/body.rb
+++ b/lib/link_thumbnailer/models/body.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'link_thumbnailer/model'
+
+module LinkThumbnailer
+  module Models
+    class Body < ::LinkThumbnailer::Model
+
+      attr_reader :node, :text
+
+      def initialize(node, text = nil)
+        @node = node
+        @text = sanitize(node.map(&:text).join(' '))
+      end
+
+      def to_s
+        text
+      end
+
+    end
+  end
+end

--- a/lib/link_thumbnailer/models/website.rb
+++ b/lib/link_thumbnailer/models/website.rb
@@ -6,7 +6,7 @@ module LinkThumbnailer
   module Models
     class Website < ::LinkThumbnailer::Model
 
-      attr_accessor :url, :title, :description, :images, :videos, :favicon
+      attr_accessor :url, :title, :description, :images, :videos, :favicon, :body
 
       def initialize
         @images = []

--- a/lib/link_thumbnailer/scraper.rb
+++ b/lib/link_thumbnailer/scraper.rb
@@ -16,6 +16,8 @@ require 'link_thumbnailer/scrapers/default/videos'
 require 'link_thumbnailer/scrapers/opengraph/videos'
 require 'link_thumbnailer/scrapers/default/favicon'
 require 'link_thumbnailer/scrapers/opengraph/favicon'
+require 'link_thumbnailer/scrapers/default/body'
+require 'link_thumbnailer/scrapers/opengraph/body'
 
 module LinkThumbnailer
   class Scraper < ::SimpleDelegator

--- a/lib/link_thumbnailer/scrapers/base.rb
+++ b/lib/link_thumbnailer/scrapers/base.rb
@@ -5,6 +5,7 @@ require 'link_thumbnailer/models/title'
 require 'link_thumbnailer/models/description'
 require 'link_thumbnailer/models/image'
 require 'link_thumbnailer/models/video'
+require 'link_thumbnailer/models/body'
 
 module LinkThumbnailer
   module Scrapers

--- a/lib/link_thumbnailer/scrapers/default/body.rb
+++ b/lib/link_thumbnailer/scrapers/default/body.rb
@@ -8,7 +8,7 @@ module LinkThumbnailer
       class Body < ::LinkThumbnailer::Scrapers::Default::Base
 
         def value
-          model.to_s
+          model.paragraphs
         end
 
         private
@@ -18,7 +18,7 @@ module LinkThumbnailer
         end
 
         def node
-          document.css('body').css('p')
+          document.css('body').css('p,h1,h2,h3,h4,h5,h6,blockquote')
         end
 
       end

--- a/lib/link_thumbnailer/scrapers/default/body.rb
+++ b/lib/link_thumbnailer/scrapers/default/body.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'link_thumbnailer/scrapers/default/base'
+
+module LinkThumbnailer
+  module Scrapers
+    module Default
+      class Body < ::LinkThumbnailer::Scrapers::Default::Base
+
+        def value
+          model.to_s
+        end
+
+        private
+
+        def model
+          modelize(node)
+        end
+
+        def node
+          document.css('body').css('p')
+        end
+
+      end
+    end
+  end
+end

--- a/lib/link_thumbnailer/scrapers/opengraph/body.rb
+++ b/lib/link_thumbnailer/scrapers/opengraph/body.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'link_thumbnailer/scrapers/opengraph/base'
+
+module LinkThumbnailer
+  module Scrapers
+    module Opengraph
+      class Body < ::LinkThumbnailer::Scrapers::Opengraph::Base
+      end
+    end
+  end
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -12,7 +12,7 @@ describe LinkThumbnailer::Configuration do
   it { expect(instance.http_open_timeout).to      eq(5) }
   it { expect(instance.http_read_timeout).to      eq(5) }
   it { expect(instance.blacklist_urls).to_not     be_empty }
-  it { expect(instance.attributes).to             eq([:title, :images, :description, :videos, :favicon]) }
+  it { expect(instance.attributes).to             eq([:title, :images, :description, :videos, :favicon, :body]) }
   it { expect(instance.graders).to_not            be_empty }
   it { expect(instance.description_min_length).to eq(50) }
   it { expect(instance.positive_regex).to_not     be_nil }

--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -101,7 +101,7 @@ describe 'Fixture' do
 
       let(:html)        { File.open(File.dirname(__FILE__) + '/fixtures/default_from_body.html').read }
       let(:description) { 'Description from body' }
-      let(:body)        { 'Body paragraph Description from body' }
+      let(:body)        { ['Body paragraph', 'Description from body'] }
 
       it { expect(action.favicon).to                eq(favicon) }
       it { expect(action.description).to            eq(description) }

--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -101,9 +101,11 @@ describe 'Fixture' do
 
       let(:html)        { File.open(File.dirname(__FILE__) + '/fixtures/default_from_body.html').read }
       let(:description) { 'Description from body' }
+      let(:body)        { 'Body paragraph Description from body' }
 
       it { expect(action.favicon).to                eq(favicon) }
       it { expect(action.description).to            eq(description) }
+      it { expect(action.body).to                   eq(description) }
       it { expect(action.images.count).to           eq(1) }
       it { expect(action.images.first.src.to_s).to  eq(png_url) }
 

--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -105,7 +105,7 @@ describe 'Fixture' do
 
       it { expect(action.favicon).to                eq(favicon) }
       it { expect(action.description).to            eq(description) }
-      it { expect(action.body).to                   eq(description) }
+      it { expect(action.body).to                   eq(body) }
       it { expect(action.images.count).to           eq(1) }
       it { expect(action.images.first.src.to_s).to  eq(png_url) }
 

--- a/spec/fixtures/default_from_body.html
+++ b/spec/fixtures/default_from_body.html
@@ -5,9 +5,13 @@
 </head>
 <body>
 
-  <p>Description from body</p>
+  <p>Body paragraph</p>
 
   <img src="http://foo.com/foo.png">
+
+  <div>Not body</div>
+
+  <p>Description from body</p>
 
 </body>
 </html>


### PR DESCRIPTION
Hi, I'm not sure this function makes sense in the context of a link thumbnailer, but I implemented it for personal use and it works, so feel free to reject this PR.

Basically when the url gets scraped, you can get the full content of all the ```<p>``` tags of the page in the ```body``` attribute (all tags stripped and squished). Maybe it can make sense as an optional attribute in the configuration.