### PR TITLE
Add full url path to favicon icon

### DIFF
--- a/lib/link_thumbnailer/scrapers/default/favicon.rb
+++ b/lib/link_thumbnailer/scrapers/default/favicon.rb
@@ -18,6 +18,7 @@ module LinkThumbnailer
           uri = ::URI.parse(href)
           uri.scheme ||= website.url.scheme
           uri.host ||= website.url.host
+          uri.path = uri.path&.sub(%r{^(?=[^\/])}, '/')
           uri
         rescue ::URI::InvalidURIError
           nil

--- a/lib/link_thumbnailer/scrapers/default/favicon.rb
+++ b/lib/link_thumbnailer/scrapers/default/favicon.rb
@@ -15,7 +15,10 @@ module LinkThumbnailer
         private
 
         def to_uri(href)
-          ::URI.parse(href)
+          uri = ::URI.parse(href)
+          uri.scheme ||= website.url.scheme
+          uri.host ||= website.url.host
+          uri
         rescue ::URI::InvalidURIError
           nil
         end

--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -109,6 +109,18 @@ describe 'Fixture' do
 
     end
 
+    context 'when favicon with root path in the href' do
+      let(:html) { File.open(File.dirname(__FILE__) + '/fixtures/with_root_path_in_href.html').read }
+
+      it { expect(action.favicon).to eq(favicon) }
+    end
+
+    context 'when favicon with related path in the href' do
+      let(:html) { File.open(File.dirname(__FILE__) + '/fixtures/with_related_path_in_href.html').read }
+
+      it { expect(action.favicon).to eq(favicon) }
+    end
+
   end
 
 end

--- a/spec/fixtures/with_related_path_in_href.html
+++ b/spec/fixtures/with_related_path_in_href.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Title from meta</title>
+  <link rel="shortcut icon" href="foo.ico">
+</head>
+<body>
+
+  <p>Description from body</p>
+
+  <img src="http://foo.com/foo.png">
+
+</body>
+</html>

--- a/spec/fixtures/with_root_path_in_href.html
+++ b/spec/fixtures/with_root_path_in_href.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Title from meta</title>
+  <link rel="shortcut icon" href="/foo.ico">
+</head>
+<body>
+
+  <p>Description from body</p>
+
+  <img src="http://foo.com/foo.png">
+
+</body>
+</html>


### PR DESCRIPTION
I think it's important to give the full URL to the favicon. Because if the favicon is in the same server with the main website favicon scrapper returns path to us.
For example. 
It was before:
```ruby
el = LinkThumbnailer.generate('https://www.cornmarket.ie/', attributes: [:favicon])
el.favicon
>>  "/images/favicon/favicon-16x16.png"
```
It is after:
```ruby
el = LinkThumbnailer.generate('https://www.cornmarket.ie/', attributes: [:favicon])
el.favicon
>>  "https://www.cornmarket.ie/images/favicon/favicon-16x16.png"
```