### PR TITLE
Add favicon size option

### DIFF
--- a/lib/generators/templates/initializer.rb
+++ b/lib/generators/templates/initializer.rb
@@ -35,6 +35,11 @@ LinkThumbnailer.configure do |config|
   #
   # config.attributes = [:title, :images, :description, :videos, :favicon]
 
+  # Prior favicon size. If the website doesn't have such size - returns the first favicon.
+  # Value should be like '32x32' or '16x16'. Default value is nil.
+  #
+  # config.favicon_size = nil
+
   # List of procedures used to rate the website description. Add you custom class
   # here. See wiki for more details on how to build your own graders.
   #

--- a/lib/link_thumbnailer/configuration.rb
+++ b/lib/link_thumbnailer/configuration.rb
@@ -28,7 +28,8 @@ module LinkThumbnailer
                   :verify_ssl, :http_open_timeout, :http_read_timeout, :attributes,
                   :graders, :description_min_length, :positive_regex, :negative_regex,
                   :image_limit, :image_stats, :raise_on_invalid_format, :max_concurrency,
-                  :scrapers, :http_override_headers, :download_size_limit, :encoding
+                  :scrapers, :http_override_headers, :download_size_limit, :encoding,
+                  :favicon_size
 
     alias_method :http_timeout, :http_open_timeout
     alias_method :http_timeout=, :http_open_timeout=

--- a/lib/link_thumbnailer/scrapers/default/favicon.rb
+++ b/lib/link_thumbnailer/scrapers/default/favicon.rb
@@ -25,13 +25,21 @@ module LinkThumbnailer
         end
 
         def node
-          document.xpath("//link[contains(@rel, 'icon')]").first
+          icons = document.xpath("//link[contains(@rel, 'icon')]")
+          retrieve_by_size(icons) || icons.first
         end
 
         def modelize(uri)
           model_class.new(uri)
         end
 
+        def retrieve_by_size(icons)
+          return if config.favicon_size.nil?
+
+          icons.find do |icon|
+            icon.attributes['sizes']&.value == config.favicon_size
+          end
+        end
       end
     end
   end

--- a/lib/link_thumbnailer/scrapers/default/favicon.rb
+++ b/lib/link_thumbnailer/scrapers/default/favicon.rb
@@ -15,7 +15,11 @@ module LinkThumbnailer
         private
 
         def to_uri(href)
-          ::URI.parse(href)
+          uri = ::URI.parse(href)
+          uri.scheme ||= website.url.scheme
+          uri.host ||= website.url.host
+          uri.path = uri.path&.sub(%r{^(?=[^\/])}, '/')
+          uri
         rescue ::URI::InvalidURIError
           nil
         end

--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -116,6 +116,18 @@ describe 'Fixture' do
 
       it { expect(action.favicon).to eq(favicon) }
     end
+
+    context 'when favicon with root path in the href' do
+      let(:html) { File.open(File.dirname(__FILE__) + '/fixtures/with_root_path_in_href.html').read }
+
+      it { expect(action.favicon).to eq(favicon) }
+    end
+
+    context 'when favicon with related path in the href' do
+      let(:html) { File.open(File.dirname(__FILE__) + '/fixtures/with_related_path_in_href.html').read }
+
+      it { expect(action.favicon).to eq(favicon) }
+    end
   end
 
 end

--- a/spec/fixture_spec.rb
+++ b/spec/fixture_spec.rb
@@ -109,6 +109,13 @@ describe 'Fixture' do
 
     end
 
+    context 'with 32 favicon size' do
+      let(:action)  { LinkThumbnailer.generate(url, favicon_size: '32x32') }
+      let(:favicon) { 'http://foo.com/foo32x32.ico' }
+      let(:html)    { File.open(File.dirname(__FILE__) + '/fixtures/default_with_few_favicons.html').read }
+
+      it { expect(action.favicon).to eq(favicon) }
+    end
   end
 
 end

--- a/spec/fixtures/default_with_few_favicons.html
+++ b/spec/fixtures/default_with_few_favicons.html
@@ -1,0 +1,15 @@
+<html>
+<head>
+  <title>Title from meta</title>
+  <link rel="shortcut icon" href="http://foo.com/foo.ico">
+  <link rel="shortcut icon" sizes='32x32' href="http://foo.com/foo32x32.ico">
+  <link rel="shortcut icon" sizes='16x16' href="http://foo.com/foo16x16.ico">
+</head>
+<body>
+
+  <p>Description from body</p>
+
+  <img src="http://foo.com/foo.png">
+
+</body>
+</html>

--- a/spec/fixtures/with_related_path_in_href.html
+++ b/spec/fixtures/with_related_path_in_href.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Title from meta</title>
+  <link rel="shortcut icon" href="foo.ico">
+</head>
+<body>
+
+  <p>Description from body</p>
+
+  <img src="http://foo.com/foo.png">
+
+</body>
+</html>

--- a/spec/fixtures/with_root_path_in_href.html
+++ b/spec/fixtures/with_root_path_in_href.html
@@ -1,0 +1,13 @@
+<html>
+<head>
+  <title>Title from meta</title>
+  <link rel="shortcut icon" href="/foo.ico">
+</head>
+<body>
+
+  <p>Description from body</p>
+
+  <img src="http://foo.com/foo.png">
+
+</body>
+</html>


### PR DESCRIPTION
I think It will be cool if this gem will have the opportunity to set desired favicon size.
For now with attribute `favicon_size:` we can choose which size will have priority. If this size doesn't exist - we return first founded favicon.
```ruby
el = LinkThumbnailer.generate('https://www.cornmarket.ie/', attributes: [:favicon], favicon_size: '32x32')
el.favicon
>> "/images/favicon/favicon-32x32.png"
```
