### PR TITLE
Fix bug with closed TCP connection

### DIFF
--- a/lib/link_thumbnailer/page.rb
+++ b/lib/link_thumbnailer/page.rb
@@ -18,6 +18,7 @@ module LinkThumbnailer
 
     def generate
       @source = processor.call(url)
+      processor.http.shutdown
       scraper.call
     end
 

--- a/lib/link_thumbnailer/page.rb
+++ b/lib/link_thumbnailer/page.rb
@@ -17,8 +17,7 @@ module LinkThumbnailer
     end
 
     def generate
-      @source = processor.call(url)
-      processor.http.shutdown
+      @source = processor.start(url)
       scraper.call
     end
 

--- a/lib/link_thumbnailer/processor.rb
+++ b/lib/link_thumbnailer/processor.rb
@@ -17,6 +17,12 @@ module LinkThumbnailer
       super(config)
     end
 
+    def start(url)
+      result = call(url)
+      shutdown
+      result
+    end
+
     def call(url = '', redirect_count = 0, headers = {})
       self.url        = url
       @redirect_count = redirect_count
@@ -33,6 +39,10 @@ module LinkThumbnailer
     end
 
     private
+
+    def shutdown
+      http.shutdown
+    end
 
     def with_valid_url
       raise ::LinkThumbnailer::BadUriFormat unless valid_url_format?


### PR DESCRIPTION
Link Thumbnailer doesn't close the HTTP connection after finished working with the server.