### PR TITLE
Added check for existence of the node's href attribute

### DIFF
--- a/lib/link_thumbnailer/scrapers/default/favicon.rb
+++ b/lib/link_thumbnailer/scrapers/default/favicon.rb
@@ -25,7 +25,7 @@ module LinkThumbnailer
         end
 
         def href
-          node.attributes['href'].value.to_s if node
+          node.attributes['href'].value.to_s if node && node.attributes['href']
         end
 
         def node


### PR DESCRIPTION
resolves #147 

NoMethodError:  undefined method `value' for nil:NilClass

Offending url: https://vm.tiktok.com/ZMRkMaRGr/

/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scrapers/default/favicon.rb:28 in href
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scrapers/default/favicon.rb:12 in value
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scrapers/base.rb:29 in call
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scraper.rb:39 in block (2 levels) in call
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scraper.rb:38 in each
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scraper.rb:38 in block in call
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scraper.rb:37 in each
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/scraper.rb:37 in call
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer/page.rb:21 in generate
/gems/link_thumbnailer-3.4.0/lib/link_thumbnailer.rb:18 in generate